### PR TITLE
Fix selection UX for list view and overlay toggle

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -99,6 +99,11 @@ html.dark .article-card:hover {
         0 8px 24px -8px rgba(0, 0, 0, 0.5) !important;
 }
 
+/* Suppress vertical lift for list-view rows — they stack and would overlap */
+.article-card[data-view="list"]:hover {
+    transform: none;
+}
+
 /* ─── Fade-in Animation ─────────────────────────────────────────────── */
 
 @keyframes fade-in {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -704,13 +704,14 @@ function toggleArticleSelection(index) {
     // Update specific card UI without full re-render
     const card = document.getElementById(`article-${index}`);
     const checkbox = document.getElementById(`checkbox-${index}`);
+    const overlay = document.getElementById(`overlay-${index}`);
     if (card && checkbox) {
-        if (selectedIndices.has(index)) {
-            card.classList.add('selected');
-            checkbox.checked = true;
-        } else {
-            card.classList.remove('selected');
-            checkbox.checked = false;
+        const nowSelected = selectedIndices.has(index);
+        card.classList.toggle('selected', nowSelected);
+        checkbox.checked = nowSelected;
+        if (overlay) {
+            overlay.classList.toggle('opacity-100', nowSelected);
+            overlay.classList.toggle('opacity-0', !nowSelected);
         }
     }
 }

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -262,7 +262,7 @@ function generateArticlesHtml(articles, startIndex, query, isSelectionMode, sele
             }
 
             return `
-                <article id="article-${index}" class="article-card group bg-white dark:bg-slate-900/70 backdrop-blur-sm rounded-2xl border border-slate-200/60 dark:border-slate-700/50 overflow-hidden flex flex-row items-start gap-0 relative transition-all duration-300 hover:shadow-md hover:border-slate-300 dark:hover:border-slate-600 ${isSelected ? 'selected' : ''}" style="--stagger-delay: ${staggerDelay}ms" ${clickHandler}>
+                <article id="article-${index}" data-view="list" class="article-card group bg-white dark:bg-slate-900/70 backdrop-blur-sm rounded-2xl border border-slate-200/60 dark:border-slate-700/50 overflow-hidden flex flex-row items-start gap-0 relative transition-all duration-300 hover:shadow-md hover:border-slate-300 dark:hover:border-slate-600 ${isSelected ? 'selected' : ''}" style="--stagger-delay: ${staggerDelay}ms" ${clickHandler}>
                     ${selectionOverlay}
                     <!-- Thumbnail -->
                     <div class="w-28 sm:w-36 shrink-0 self-stretch overflow-hidden bg-slate-100 dark:bg-slate-800">


### PR DESCRIPTION
## Summary

- Suppress hover lift (`translateY(-3px)`) on list-view rows so stacked items don't visually overlap on hover
- Fix selection overlay opacity not toggling when selecting/deselecting articles — now correctly syncs `opacity-0`/`opacity-100` alongside the card's `selected` class and checkbox state (was broken in both views)